### PR TITLE
[WIP] Implements R2DBC for application

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-//    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
+    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
@@ -38,7 +38,7 @@ dependencies {
 
     runtimeOnly("org.postgresql:postgresql")
     runtimeOnly("org.springframework.boot:spring-boot-devtools")
-//    runtimeOnly("org.postgresql:r2dbc-postgresql")
+    runtimeOnly("org.postgresql:r2dbc-postgresql")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   app:
     restart: always
     environment:
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://database:5432/maestro
+      - SPRING_DATASOURCE_URL=r2dbc:postgresql://database:5432/maestro
       - SPRING_DATASOURCE_USERNAME=admin
       - SPRING_DATASOURCE_PASSWORD=admin
     build:

--- a/kubernetes/maestro-app/maestro-app.yaml
+++ b/kubernetes/maestro-app/maestro-app.yaml
@@ -20,4 +20,4 @@ spec:
             - containerPort: 8080
           env:
             - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://svc-postgres:5432/maestro
+              value: r2dbc:postgresql://svc-postgres:5432/maestro

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ management.endpoints.web.base-path=/
 springdoc.swagger-ui.path=/swagger-ui
 
 db.schema=maestro
-db.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/maestro}
+db.url=${SPRING_DATASOURCE_URL:r2dbc:postgresql://localhost:5432/maestro}
 db.username=${SPRING_DATASOURCE_USERNAME:admin}
 db.password=${SPRING_DATASOURCE_USERNAME:admin}
 


### PR DESCRIPTION
Neste PR estamos substituindo o JDBC pelo R2DBC. Assim, nossa aplicação passa a acessar a base de dados reativamente, não sendo mais necessário encapsular chamadas ao banco no `runBlocking { ... }`